### PR TITLE
SignUp 페이지 구현하기

### DIFF
--- a/SignUp/SignUp/SecondViewController.swift
+++ b/SignUp/SignUp/SecondViewController.swift
@@ -70,6 +70,7 @@ class SecondViewController: UIViewController, UIImagePickerControllerDelegate, U
         }
     }
     
+<<<<<<< HEAD
 //    func textViewDidEndEditing(_ sender: UITextView!){
 //        print("\(idTextField.text!) \(passwordTextField.text!) \(passwordCheckTextField.text!)")
 //        let placehold:String = "자기소개 입력"
@@ -84,6 +85,22 @@ class SecondViewController: UIViewController, UIImagePickerControllerDelegate, U
 //            self.enableBtn(isOn: true)
 //            }
 //    }
+=======
+    func textViewDidEndEditing(_ sender: UITextView!){
+        print("\(idTextField.text!) \(passwordTextField.text!) \(passwordCheckTextField.text!)")
+        let placehold:String = "자기소개 입력"
+        if sender.text.isEmpty{
+            sender.text=placehold
+            self.enableBtn(isOn: false)
+        }else if sender.text == placehold{
+            sender.text=""
+            self.enableBtn(isOn: false)
+        }else if textfieldisFill(), passwordCheck(passwordTextField, passwordCheckTextField) {
+            NextButton.isUserInteractionEnabled = true
+            self.enableBtn(isOn: true)
+            }
+    }
+>>>>>>> cee420e... 키보드 올리기, 버튼 활성화
     
     @IBAction func textFieldDidEndEditing(_ textField: UITextField){
         if textField.text?.isEmpty == true{

--- a/SignUp/SignUp/SecondViewController.swift
+++ b/SignUp/SignUp/SecondViewController.swift
@@ -70,20 +70,20 @@ class SecondViewController: UIViewController, UIImagePickerControllerDelegate, U
         }
     }
     
-    func textViewDidEndEditing(_ sender: UITextView!){
-        print("\(idTextField.text!) \(passwordTextField.text!) \(passwordCheckTextField.text!)")
-        let placehold:String = "자기소개 입력"
-        if sender.text.isEmpty{
-            sender.text=placehold
-            self.enableBtn(isOn: false)
-        }else if sender.text == placehold{
-            sender.text=""
-            self.enableBtn(isOn: false)
-        }else if textfieldisFill(), passwordCheck(passwordTextField, passwordCheckTextField) {
-            NextButton.isUserInteractionEnabled = true
-            self.enableBtn(isOn: true)
-            }
-    }
+//    func textViewDidEndEditing(_ sender: UITextView!){
+//        print("\(idTextField.text!) \(passwordTextField.text!) \(passwordCheckTextField.text!)")
+//        let placehold:String = "자기소개 입력"
+//        if sender.text.isEmpty{
+//            sender.text=placehold
+//            self.enableBtn(isOn: false)
+//        }else if sender.text == placehold{
+//            sender.text=""
+//            self.enableBtn(isOn: false)
+//        }else if textfieldisFill(), passwordCheck(passwordTextField, passwordCheckTextField) {
+//            NextButton.isUserInteractionEnabled = true
+//            self.enableBtn(isOn: true)
+//            }
+//    }
     
     @IBAction func textFieldDidEndEditing(_ textField: UITextField){
         if textField.text?.isEmpty == true{


### PR DESCRIPTION
## View1 : 로그인 화면
###  화면구성
 🎯 아이디와 패스워드를 입력하는 필드가 있고, 각각 알맞은 플레이스홀더(placeholder)가 적혀있습니다.
 🎯 상단에는 사이트와 관련된 이미지를 보여주며, 그 아래에는 로그인 버튼과 회원가입 버튼이 있습니다.
### 기능
🎯 로그인 버튼은 눌러도 아무 반응이 없으며 회원가입 버튼을 누르면 화면2로 전환됩니다. 
👍  탭 제스처 사용 - 키보드 내려가기 

## View2: 정보 입력 1
### 화면구성
🎯 상단 오른쪽에는 아이디, 패스워드, 패스워드 확인을 하는 필드가 있고, 각각 알맞은 플레이스홀더(placeholder)가 적혀있습니다.
🎯 상단 왼쪽에 이미지뷰가 있고, 그 아래에는 자기소개를 위한 텍스트뷰가 위치합니다.
🎯 텍스트뷰 아래의 왼쪽에는 '취소'버튼이 위치하며, 그 오른쪽에는 '다음'버튼이 위치합니다.
### 기능
   🎯 상단 왼쪽의 이미지뷰를 탭하면 UIImagePickerController가 뜨고, 이미지를 간단히 편집해 프로필 사진으로 선택할 수 있습니다.
   🎯 프로필 이미지뷰는 정사각형이며, 이미지뷰 내부에 보이는 이미지는 이미지 원래의 비율을 유지합니다.
   🎯화면 중간의 텍스트 뷰에서 자기소개를 작성할 수 있습니다.
   🎯화면 왼쪽 하단의 '취소' 버튼을 누르면 모든 정보가 지워지고 이전 화면1로 되돌아갑니다.
   🎯 사용자가 모든 정보를 기입한 상태가 아니라면 화면 오른쪽 하단의 '다음' 버튼은 기본적으로 비활성화되어있으며, 프로필 이미지, 아이디, 자기소개가 모두 채워지고, 패스워드가 일치하면 '다음' 버튼이 활성화됩니다.

   👍 키보드 올라갈 때 뷰 올라감
   👎  이미지가 비어 있어도 버튼 활성화됨

## View3: 정보 입력 2
### 화면구성
 🎯 화면 상단에는 전화번호를 입력할 수 있는 텍스트 필드가 있습니다.
 🎯 텍스트 필드 하단에는 선택한 생년월일을 표시할 수 있는 레이블이 있으며 그 하단에는 날짜를 선택할 수 있는 피커가 있습니다.
 🎯 피커 하단에는 '이전', '취소', '가입' 버튼이 위치합니다.
### 기능
   🎯 사용자가 모든 정보를 기입한 상태가 아니라면 '가입' 버튼은 기본적으로 비활성화되어있습니다. 전화번호와 생년월일이 채워지면 '가입' 버튼이 활성화됩니다. 또, 활성화된 '가입' 버튼을 선택하면 화면1로 되돌아가고, 가입한 아이디가 화면1의 아이디 필드에 입력되어있습니다.
    🎯 '이전' 버튼을 누르면 현재 정보를 저장해두고 화면2로 돌아가며, '취소' 버튼을 누르면 모든 정보가 지워지고 화면1로 돌아갑니다.
   🎯 전화번호 필드를 누르면 숫자키패드가 올라옵니다.
   🎯 생년월일 선택은 UIDatePicker를 활용합니다.
   🎯  UIDatePicker의 숫자가 바뀌면 생년월일 레이블에 즉각 반영됩니다.

   👍 키보드 올라갈 때 뷰 올라감

## 싱글톤
  🎯 애플리케이션 구현에 필요한 싱글턴 인스턴스를 생성하여 활용합니다.
    * 싱글턴 클래스 이름은 UserInformation으로 합니다.
